### PR TITLE
Add a version define for Unity 2020 to fix build error

### DIFF
--- a/Runtime/DefaultPredictionSimulation.cs
+++ b/Runtime/DefaultPredictionSimulation.cs
@@ -30,7 +30,15 @@ namespace JamesFrowen.CSP.Simulations
                     Physics.autoSimulation = false;
                     break;
                 case SimulationMode.Physics2D:
+#if UNITY_2020_1_OR_NEWER
+                    // Unity 2020.1+ deprecated Physics2D.autoSimulation, using that causes a Compile Error
+                    // when building the player. So we set the simulation mode for 2D Physics to be controlled
+                    // via Script.
+                    Physics2D.simulationMode = SimulationMode2D.Script;
+#else
+                    // Stock standard disabling of 2D Physics auto simulation.
                     Physics2D.autoSimulation = false;
+#endif
                     break;
                 case SimulationMode.Local3D:
                     local3d = scene.GetPhysicsScene();
@@ -52,7 +60,13 @@ namespace JamesFrowen.CSP.Simulations
                     Physics.autoSimulation = false;
                     break;
                 case SimulationMode.Physics2D:
+#if UNITY_2020_1_OR_NEWER
+                    // Unity 2020.1+ deprecated Physics2D.autoSimulation. See previous comments above in DefaultPredictionSimulation(mode, scene)
+                    Physics2D.simulationMode = SimulationMode2D.Script;
+#else
+                    // Stock standard disabling of 2D Physics auto simulation.
                     Physics2D.autoSimulation = false;
+#endif
                     break;
                 case SimulationMode.Local3D:
                 case SimulationMode.Local2D:


### PR DESCRIPTION
On Unity 2020 LTS, if I attempt to compile the code out of the box into a standalone player, I will get a build error about `Physics2D.autoSimulation` not existing in the `Physics2D` class. This PR is a simple fix with commentary - if using Unity 2020 LTS, then use the proper way, otherwise use the obsolete way.