### PR TITLE
refactor: native memory zeroing via native imports

### DIFF
--- a/Assets/source/Runtime/Alloc/AllocHelper.cs
+++ b/Assets/source/Runtime/Alloc/AllocHelper.cs
@@ -49,14 +49,10 @@ namespace JamesFrowen.CSP.Alloc
         [SuppressUnmanagedCodeSecurity]
         [DllImport("msvcrt.dll", EntryPoint = "memset", CallingConvention = CallingConvention.Cdecl, SetLastError = false)]
         static extern IntPtr memset(IntPtr dest, int value, UIntPtr byteCount);
-#elif UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX
+#elif UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX || UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
         [SuppressUnmanagedCodeSecurity]
         [DllImport("libc", EntryPoint = "memset", CallingConvention = CallingConvention.Cdecl, SetLastError = false)]
-        static extern IntPtr memset(IntPtr dest, int value, UIntPtr byteCount);    
-#elif UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
-        [SuppressUnmanagedCodeSecurity]
-        [DllImport("libc", EntryPoint = "memset", CallingConvention = CallingConvention.Cdecl, SetLastError = false)]
-        static extern IntPtr memset(IntPtr dest, int value, UIntPtr byteCount);  
+        static extern IntPtr memset(IntPtr dest, int value, UIntPtr byteCount);
 #endif
         #endregion
     }

--- a/Assets/source/Runtime/Alloc/AllocHelper.cs
+++ b/Assets/source/Runtime/Alloc/AllocHelper.cs
@@ -9,6 +9,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Security;
 
 namespace JamesFrowen.CSP.Alloc
 {

--- a/Assets/source/Runtime/Alloc/AllocHelper.cs
+++ b/Assets/source/Runtime/Alloc/AllocHelper.cs
@@ -36,5 +36,21 @@ namespace JamesFrowen.CSP.Alloc
                 ptr[i] = 0;
             }
         }
+
+        #region Platform-dependent Imports
+#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
+        [SuppressUnmanagedCodeSecurity]
+        [DllImport("msvcrt.dll", EntryPoint = "memset", CallingConvention = CallingConvention.Cdecl, SetLastError = false)]
+        static extern IntPtr memset(IntPtr dest, int value, UIntPtr byteCount);
+#elif UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX
+        [SuppressUnmanagedCodeSecurity]
+        [DllImport("libc", EntryPoint = "memset", CallingConvention = CallingConvention.Cdecl, SetLastError = false)]
+        static extern IntPtr memset(IntPtr dest, int value, UIntPtr byteCount);    
+#elif UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
+        [SuppressUnmanagedCodeSecurity]
+        [DllImport("libc", EntryPoint = "memset", CallingConvention = CallingConvention.Cdecl, SetLastError = false)]
+        static extern IntPtr memset(IntPtr dest, int value, UIntPtr byteCount);  
+#endif
+        #endregion
     }
 }

--- a/Assets/source/Runtime/Alloc/AllocHelper.cs
+++ b/Assets/source/Runtime/Alloc/AllocHelper.cs
@@ -14,7 +14,7 @@ namespace JamesFrowen.CSP.Alloc
 {
     public static class AllocHelper
     {
-        public static void ZeroMemory(IntPtr ptr, int byteLengthh)
+        public static void ZeroMemory(IntPtr ptr, int byteLength)
         {
 #if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
             RtlZeroMemory(ptr, new UIntPtr((uint)byteLengthh));

--- a/Assets/source/Runtime/Alloc/AllocHelper.cs
+++ b/Assets/source/Runtime/Alloc/AllocHelper.cs
@@ -16,19 +16,22 @@ namespace JamesFrowen.CSP.Alloc
     {
         public static void ZeroMemory(IntPtr ptr, int byteLength)
         {
-#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
-            RtlZeroMemory(ptr, new UIntPtr((uint)byteLengthh));
+#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WINDOWS || UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX || UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
+            // We're a Windows, Mac or Linux platform: Use native's memset function. 
+            memset((IntPtr)ptr, 0, (UIntPtr)byteLength);
 #else
-            ZeroNonWindwos(ptr, byteLengthh);
+            // Fail-safe for all the other platforms (mobile, console (?), ...)
+            ZeroMemoryFallback(ptr, byteLength);
 #endif
         }
 
-#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
-        [DllImport("kernel32.dll")]
-        private static extern void RtlZeroMemory(IntPtr dst, UIntPtr length);
-#endif
-
-        private static unsafe void ZeroNonWindwos(IntPtr dst, int length)
+        /// <summary>
+        /// Zeroes memory in the native world. Beware, improper use of this
+        /// functionality will likely make things explode.
+        /// </summary>
+        /// <param name="dst"></param>
+        /// <param name="length"></param>
+        private static unsafe void ZeroMemoryFallback(IntPtr dst, int length)
         {
             var ptr = (byte*)dst;
             for (var i = 0; i < length; i++)

--- a/Assets/source/Runtime/Alloc/AllocHelper.cs
+++ b/Assets/source/Runtime/Alloc/AllocHelper.cs
@@ -5,6 +5,9 @@
  * 
  * The code below can not be copied and/or distributed without the express
  * permission of James Frowen
+ * 
+ * 2023-01-22: Modified by Matt Coburn (SoftwareGuy) with additions from FakeByte from
+ * the Mirage Discord to improve native memory zeroing on multiple platforms.
  *******************************************************/
 
 using System;


### PR DESCRIPTION
As per private discussions in the Discord, this is a patch PR that allows Windows instances using the CSP system to use `memset` provided by the Visual C Runtime that comes with Windows, and (g)Libc on *nix and Mac OS.

Don't merge just yet, I will test on Windows and Linux before giving the OK to merge.